### PR TITLE
[.vim] Support `hub pull-request` syntax

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -1,6 +1,13 @@
 call pathogen#helptags()
 call pathogen#runtime_prepend_subdirectories(expand('<sfile>:h').'/.vim/bundles')
 
+" Add `hub pull-request` syntax highlighting to vim, if installed via homebrew
+"
+" TODO:  Support other platforms
+if isdirectory('/usr/local/share/vim')
+  call pathogen#runtime_prepend_subdirectories('/usr/local/share/vim')
+endif
+
 "These options and commands enable some very useful features in Vim, that
 " no user should have to live without.
 


### PR DESCRIPTION
As of this PR:  https://github.com/github/hub/pull/1939

There is support for syntax highlighting for pull request files when using `hub pull-request`.

This change adds the `/usr/local/share/vim/vimfiles` directory as part of pathogen's path structure, if it exists.  Other platforms could be added in the future if desired.


Edit:  Holy $H1T... I have a old a$$ version of pathogen in use in this repo...