### PR TITLE
[.bashrc.d] Better Homebrew completion

### DIFF
--- a/.bashrc.d/.completion
+++ b/.bashrc.d/.completion
@@ -7,4 +7,15 @@
 
 
 source_file /etc/bash_completion
-which -s brew && source_file $(brew --prefix)/etc/bash_completion
+
+if type brew &>/dev/null; then
+  HOMEBREW_PREFIX=$(brew --prefix)
+  if [[ -r "${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh" ]]; then
+    source "${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh"
+  else
+    for COMPLETION in "${HOMEBREW_PREFIX}/etc/bash_completion.d/"*; do
+      [[ -r "$COMPLETION" ]] && source "$COMPLETION"
+    done
+  fi
+fi
+


### PR DESCRIPTION
Handles loading up completion scripts from Homebrew better than previously done.