### PR TITLE
[.vimrc.d] Allow toggling of whitespace stripping

### DIFF
--- a/.vimrc.d/whitespace.vim
+++ b/.vimrc.d/whitespace.vim
@@ -1,5 +1,8 @@
 " Strip trailing whitespace
 function! <SID>StripTrailingWhitespaces()
+  if exists('b:whitespace') && !b:whitespace
+    return
+  endif
   " Preperation stuff: save last search, and cursor position.
   let _s=@/
   let l = line(".")


### PR DESCRIPTION
Previously, all trailing whitespace from ruby, javascript, and eruby file types would be stripped.  There are times where this isn't desired (when dealing with HEREDOCS for example.

This change allows toggling this feature off by enabling a variable for the buffer called `b:whitespace`.  To toggle, in command mode do:

```
:let b:whitespace=0
```

And the script will eject early on save, and not strip whitespace.