### PR TITLE
[vimrc] Add --no-messages to grepprg

### DIFF
--- a/.vimrc.d/search.vim
+++ b/.vimrc.d/search.vim
@@ -52,7 +52,7 @@ let &cpo = s:save_cpo | unlet s:save_cpo
 " Setup builtin grep search to use alternative runtimes, if available
 if executable('rg')
   " Use rg over grep
-  set grepprg=rg\ --no-heading\ --vimgrep
+  set grepprg=rg\ --no-heading\ --vimgrep\ --no-messages
 elseif executable('ack')
   " Use ack over grep
   set grepprg=ack\ --nogroup


### PR DESCRIPTION
Adds the `--no-messages` flag to the grep program flag, which does the following (from `man rg`):

```man
   --no-messages
       Suppress all error messages related to opening and reading files. Error messages related to the syntax of the pattern given are still shown.

       This flag can be disabled with the --messages flag.
```