### PR TITLE
Break out Darwin specific setups

### DIFF
--- a/setup.darwin.sh
+++ b/setup.darwin.sh
@@ -43,5 +43,19 @@ if [[ $(uname -s) == "Darwin" ]] ; then
     brew install homebrew/cask-fonts/font-meslo-for-powerline
   fi
 
+  # Set default shell to "brew bash"
+  #
+  # Original instructions here:  https://itnext.io/upgrading-bash-on-macos-7138bd1066ba
+  #
+  if [[ -x /usr/local/bin/bash ]]; then
+    # use ZSH since we know it will be there on Darwin
+    #
+    # ... however, this script was written in bash... so not sure if it will
+    # port to zsh (which we will be using to run it).... oh well...
+
+    sudo /bin/zsh -c "echo '/usr/local/bin/bash' > /etc/shells"
+    chsh -s /usr/local/bin/bash
+  fi
+
   cd $CURRENT_WORKING_DIR
 fi

--- a/setup.darwin.sh
+++ b/setup.darwin.sh
@@ -29,5 +29,19 @@ if [[ $(uname -s) == "Darwin" ]] ; then
   killall SystemUIServer
 
 
+  # Install Hombrew if it doesn't already exist
+  command -v brew > /dev/null
+  if [[ "$?" != "0" ]]; then
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+
+    brew install bash
+    brew install tmux
+    brew install hub
+    brew install ruby-install
+    brew install chruby
+    # brew install iterm2  # maybe another time...
+    brew install homebrew/cask-fonts/font-meslo-for-powerline
+  fi
+
   cd $CURRENT_WORKING_DIR
 fi

--- a/setup.darwin.sh
+++ b/setup.darwin.sh
@@ -1,0 +1,33 @@
+if [[ $(uname -s) == "Darwin" ]] ; then
+  CURRENT_WORKING_DIR=`pwd`
+  cd $HOME
+
+  rm -rf ".bashrc"
+  remove_and_reload ".bash_profile" ".bashrc"
+
+  # Changes screenshots to be stored in ~/Pictures/screenshots
+  mkdir -p ~/Pictures/screenshots/
+  defaults write com.apple.screencapture location ~/Pictures/screenshots/
+
+  # Lock Screen with `CMD-L`
+  #
+  # Note:  This seems to take a while to take effect
+  #
+  # Other key short hands
+  #
+  #     command = $
+  #     control = ^
+  #     option  = ~
+  #     shift   = @
+  #
+  # Note:  The above seem wrong, as '@l' below is definitely CMD-l ...
+  #
+  # List sourced from here: https://apple.stackexchange.com/a/294411
+  #
+  defaults write -g NSUserKeyEquivalents -dict-add "Lock Screen" "@l"
+
+  killall SystemUIServer
+
+
+  cd $CURRENT_WORKING_DIR
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -35,36 +35,6 @@ remove_and_reload ".vimrc.d"
 
 mkdir .vim_swap
 
-
-if [[ $(uname -s) == "Darwin" ]] ; then
-  rm -rf ".bashrc"
-  remove_and_reload ".bash_profile" ".bashrc"
-
-  # Changes screenshots to be stored in ~/Pictures/screenshots
-  mkdir -p ~/Pictures/screenshots/
-  defaults write com.apple.screencapture location ~/Pictures/screenshots/
-
-  # Lock Screen with `CMD-L`
-  #
-  # Note:  This seems to take a while to take effect
-  #
-  # Other key short hands
-  #
-  #     command = $
-  #     control = ^
-  #     option  = ~
-  #     shift   = @
-  #
-  # Note:  The above seem wrong, as '@l' below is definitely CMD-l ...
-  #
-  # List sourced from here: https://apple.stackexchange.com/a/294411
-  #
-  defaults write -g NSUserKeyEquivalents -dict-add "Lock Screen" "@l"
-
-  killall SystemUIServer
-fi
-
-
 # Setup git credentials in ~/.gitconfig.local
 echo; echo;
 read -p "Enter your git user.name: "  GIT_USER_NAME
@@ -76,5 +46,6 @@ cat > .gitconfig.local <<EOF
   email = $GIT_EMAIL
 EOF
 
-
 cd $CURRENT_WORKING_DIR
+
+source setup.darwin.sh


### PR DESCRIPTION
In addition, it also:

- Installs `homebrew` (if not already installed)
- Adds common packages via `brew` (only if it didn't exist previously)
- Makes "brew bash" the default