### PR TITLE
[.vimrc] Fix <leader> keybinds

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -189,6 +189,10 @@ autocmd Filetype *.h set tabstop=8
 "------------------------------------------------------------
 " Load Plugin Files
 
+" Set before all plugin files so we have it available as keybindings in any of
+" them (otherwise some keybindings might stop working)
+let mapleader = ";"
+
 let dir_name = expand('<sfile>:p:h')
 for plugin_file in split(globpath(dir_name, '.vimrc.d/*'), '\n')
   execute 'source' plugin_file

--- a/.vimrc.d/keybindings.vim
+++ b/.vimrc.d/keybindings.vim
@@ -1,5 +1,3 @@
-let mapleader = ";"
-
 " Map Y to act like D and C, i.e. to yank until EOL, rather than act as yy,
 " which is the default
 map Y y$


### PR DESCRIPTION
When moving some common keybinds to a deticated keybindings.vim file, the `let mapleader = ";"` line was also moved.

This proved to be a problem if it wasn't set and a keybinding made use of it via `<leader>`.  This puts that line back in the `.vimrc`, and a friendly reminder to not be a derp.