### PR TITLE
[.vimrc] Allow for reloading

### DIFF
--- a/.vimrc.d/airline_config.vim
+++ b/.vimrc.d/airline_config.vim
@@ -34,7 +34,7 @@ let g:airline_symbols.paste = '∥'
 let g:airline_symbols.whitespace = 'Ξ'
 
 
-command AirlineToggleBranch call <SID>AirlineToggleBranch()
+command! AirlineToggleBranch call <SID>AirlineToggleBranch()
 function! s:AirlineToggleBranch()
   if g:airline_section_b == ''
     let g:airline_section_b = '%{airline#util#wrap(airline#extensions#branch#get_head(),0)}'

--- a/.vimrc.d/custom_functions.vim
+++ b/.vimrc.d/custom_functions.vim
@@ -3,7 +3,7 @@
 
 " http://stackoverflow.com/questions/2575545/vim-pipe-selected-text-to-shell-cmd-and-receive-output-on-vim-info-command-line
 " Not sure if I will keep it or not
-function PipeSelection() range
+function! PipeSelection() range
   echo system('echo '.shellescape(join(getline(a:firstline, a:lastline), "\n")).'| pbcopy')
 endfunction
 
@@ -23,7 +23,7 @@ endfunc
 " http://stackoverflow.com/a/29179159
 "
 " command Bd  \| bd \#
-command Bd call <SID>BuffDeleteAndReturnToLastBuff()
+command! Bd call <SID>BuffDeleteAndReturnToLastBuff()
 
 function! s:BuffDeleteAndReturnToLastBuff()
   exec "b #"

--- a/.vimrc.d/pull_request.vim
+++ b/.vimrc.d/pull_request.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufRead ISSUE_EDITMSG set filetype=pullrequest

--- a/.vimrc.d/spellcheck.vim
+++ b/.vimrc.d/spellcheck.vim
@@ -39,7 +39,7 @@ function! s:Spellcheck()
 endfunction
 
 " Trigger s:Spellcheck() by typing :Spellcheck
-command Spellcheck call <SID>Spellcheck()
+command! Spellcheck call <SID>Spellcheck()
 
 " Trigger s:Spellcheck() on specific filetypes
 "


### PR DESCRIPTION
Previously, when reloading my vimrc via:

```
:source $MYVIMRC
```

A bunch of errors would show up.

```
Error detected while processing /Users/nicklamuro/code/personal/dotfiles/.vimrc.d/airline_config.vim:
line   37:
E174: Command already exists: add ! to replace it
Error detected while processing /Users/nicklamuro/code/personal/dotfiles/.vimrc.d/custom_functions.vim:
line    8:
E122: Function PipeSelection already exists, add ! to replace it
line   26:
E174: Command already exists: add ! to replace it
Error detected while processing /Users/nicklamuro/code/personal/dotfiles/.vimrc.d/spellcheck.vim:
line   42:
E174: Command already exists: add ! to replace it
```

This implements those suggestions to fix the errors.  The functions in question are safe to be overwritten if the configs are reloaded (or even loaded for the first time)