### PR TITLE
[bin/mux] Safer name generation

### DIFF
--- a/bin/mux
+++ b/bin/mux
@@ -1,2 +1,3 @@
 #!/bin/bash
-tmux new -s `basename $(pwd)`
+muxdir=$(pwd)
+tmux new -s `basename ${muxdir//./-}`


### PR DESCRIPTION
Tmux doesn't allow dots (.) in it's session names, so this does a brief string substitution of the `pwd` prior to calling `tmux new -s ...`