### PR TITLE
[.tmux/keybindings.conf] Fixes swap-window calls

### DIFF
--- a/.tmux/keybindings.conf
+++ b/.tmux/keybindings.conf
@@ -24,8 +24,8 @@ bind-key q       confirm-before kill-session
 bind-key Q       confirm-before kill-server
 bind-key -r ,    previous-window # <
 bind-key -r .    next-window     # >
-bind-key -r <    swap-window -t :-
-bind-key -r >    swap-window -t :+
+bind-key -r <    swap-window -dt :-
+bind-key -r >    swap-window -dt :+
 bind-key -r \{   switch-client -p
 bind-key -r \}   switch-client -n
 bind-key [       switch-client -l


### PR DESCRIPTION
Adding `-d` allows it to retain previous functionality.

Ref:  https://github.com/tmux/tmux/issues/2160#issuecomment-610350199