### PR TITLE
[.gitconfig] Add default pull merge strategy

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -11,6 +11,8 @@
   hist = log --pretty=format:\"%C(red)%h%C(cyan) %aN%C(reset) -%C(yellow)%d%C(reset) %s %C(green)(%ar)%C(reset)\" --graph --color
   msg = show -s --format="%s%n%n%b"
   stat = show --color --format=\"%n%C(yellow)%h %C(blue bold)%s%C(reset)\" --stat
+[pull]
+  ff = only
 [push]
   default = tracking
 [color]


### PR DESCRIPTION
Avoids getting the following on startup

```console
$ git pull
hint: Pulling without specifying how to reconcile divergent branches is
hint: discouraged. You can squelch this message by running one of the following
hint: commands sometime before your next pull:
hint:
hint:   git config pull.rebase false  # merge (the default strategy)
hint:   git config pull.rebase true   # rebase
hint:   git config pull.ff only       # fast-forward only
hint:
hint: You can replace "git config" with "git config --global" to set a default
hint: preference for all repositories. You can also pass --rebase, --no-rebase,
hint: or --ff-only on the command line to override the configured default per
hint: invocation.
```

Went with `ff` to avoid mucking anything up with a rebase/merge and adding commits.  Might change in the future, but generally I am not pulling something with a divergent branch, so this should be okay (and if I am, I hope it would error).