### PR TITLE
.tmux/keybindings.conf: Sort by name in sessions view

### DIFF
--- a/.tmux/keybindings.conf
+++ b/.tmux/keybindings.conf
@@ -39,6 +39,7 @@ bind-key Up      copy-mode -u
 bind-key r       source ~/.tmux.conf \; display-message " ✱ ~/.tmux.conf is reloaded"
 bind-key R       refresh-client
 bind-key a       send-key C-a
+bind-key s       choose-tree -sZ -O name
 bind-key S       set-option status
 bind-key J       resize-pane -D 5
 bind-key K       resize-pane -U 5


### PR DESCRIPTION
Not what I am used to any more, but easier to define the sort order myself this way.